### PR TITLE
Fixed CI breaking sceneloaded event if failed to spawn computer

### DIFF
--- a/ComputerInterface.Commands/Directory.Build.props
+++ b/ComputerInterface.Commands/Directory.Build.props
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8" ?>
 <Project>
 	<PropertyGroup>
-		<GamePath>C:\Program Files (x86)\Steam\steamapps\common\Gorilla Tag</GamePath>
+		<GamePath>/home/crafterbot/.local/share/Steam/steamapps/common/Gorilla Tag/</GamePath>
 		<GameAssemblyPath>$(GamePath)\Gorilla Tag_Data\Managed</GameAssemblyPath>
 		<BepInExAssemblyPath>$(GamePath)\BepInEx\core</BepInExAssemblyPath>
 		<PluginsPath>$(GamePath)\BepInEx\plugins</PluginsPath>

--- a/ComputerInterface/CustomComputer.cs
+++ b/ComputerInterface/CustomComputer.cs
@@ -156,25 +156,32 @@ namespace ComputerInterface
 
         private void OnSceneLoaded(Scene scene, LoadSceneMode loadMode)
         {
-            string sceneName = scene.name;
-
-            if (loadMode == LoadSceneMode.Additive)
+            try 
             {
-                if (sceneName == "Cave")
-                    PrepareMonitor(scene, "Cave_Main_Prefab/OldCave/MinesComputer/GorillaComputerObject/ComputerUI");
-                
-                switch (ZoneManagement.instance.activeZones.First())
+                string sceneName = scene.name;
+
+                if (loadMode == LoadSceneMode.Additive)
                 {
-                    case GTZone.monkeBlocks:
-                        PrepareMonitor(SceneManager.GetSceneByName("GorillaTag"), "Environment Objects/MonkeBlocksRoomPersistent/MonkeBlocksComputer/GorillaComputerObject/ComputerUI");
-                        break;
-                    case GTZone.monkeBlocksShared:
-                        PrepareMonitor(SceneManager.GetSceneByName("GorillaTag"), "Environment Objects/LocalObjects_Prefab/SharedBlocksMapSelectLobby/GorillaComputerObject/ComputerUI");
-                        break;
-                    default:
-                        PrepareMonitor(scene, scene.GetComponentInHierarchy<GorillaComputerTerminal>().gameObject.transform.GetChild(0).GetPath());
-                        break;
+                    if (sceneName == "Cave")
+                        PrepareMonitor(scene, "Cave_Main_Prefab/OldCave/MinesComputer/GorillaComputerObject/ComputerUI");
+                    
+                    switch (ZoneManagement.instance.activeZones.First())
+                    {
+                        case GTZone.monkeBlocks:
+                            PrepareMonitor(SceneManager.GetSceneByName("GorillaTag"), "Environment Objects/MonkeBlocksRoomPersistent/MonkeBlocksComputer/GorillaComputerObject/ComputerUI");
+                            break;
+                        case GTZone.monkeBlocksShared:
+                            PrepareMonitor(SceneManager.GetSceneByName("GorillaTag"), "Environment Objects/LocalObjects_Prefab/SharedBlocksMapSelectLobby/GorillaComputerObject/ComputerUI");
+                            break;
+                        default:
+                            PrepareMonitor(scene, scene.GetComponentInHierarchy<GorillaComputerTerminal>().gameObject.transform.GetChild(0).GetPath());
+                            break;
+                    }
                 }
+            } 
+            catch (Exception ex)
+            {
+                Debug.LogError(ex);
             }
         }
 

--- a/ComputerInterface/Directory.Build.props
+++ b/ComputerInterface/Directory.Build.props
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8" ?>
 <Project>
 	<PropertyGroup>
-		<GamePath>C:\Program Files (x86)\Steam\steamapps\common\Gorilla Tag</GamePath>
+		<GamePath>/home/crafterbot/.local/share/Steam/steamapps/common/Gorilla Tag/</GamePath>
 		<GameAssemblyPath>$(GamePath)\Gorilla Tag_Data\Managed</GameAssemblyPath>
 		<BepInExAssemblyPath>$(GamePath)\BepInEx\core</BepInExAssemblyPath>
 		<PluginsPath>$(GamePath)\BepInEx\plugins</PluginsPath>


### PR DESCRIPTION
If a error occurs in the scene loaded event it will cause all other event listeners to not execute. Which in my case broke a mod me and Chin are working on. Quick solution: Add try-catch and log any exceptions. 

<img width="391" height="93" alt="image" src="https://github.com/user-attachments/assets/6300a25d-d769-4fa6-a59d-28bc5ccefa83" />
